### PR TITLE
v0.3.1 Add handy lists to McLag model

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,29 +90,13 @@ Version 0.3 and newer of the `netbox-plugin-mclag` plugin have added compatibili
 
 The plugin has been developed for Python 3.12.3, but I expect it to work with any Python version supported by Netbox.
 
-## Installation
+## Installation 
 
-Navigate to the directory you wish to download the plugin into. For this example, we will use ```/opt/netbox-plugin```. If the directory is not already created, you can create it using ```mkdir /opt/netbox-plugin```.
+The git repository is published to PyPi as ```netbox-plugin-mclag```
+- Add ```netbox-plugin-mclag``` to the ```/opt/netbox/local_requirements.txt``` (to make sure it is installed when upgrading)
+- Install the plugin library using the venv python ```/opt/netbox/venv/bin/python -m pip install netbox-plugin-mclag```
 
-Once the directory is created, use ```cd /opt/netbox-plugin``` to enter it.
-
-You will then need to clone the repository using git clone.
-
-```git clone https://github.com/pv2b/netbox-plugin-mclag.git```
-
-This will download the repo containing the plugin to your current working directory. Use ```cd netbox-plugin-mclag``` to enter that directory.
-
-Before installing the plugin, you will then need to activate your venv for Netbox (make sure to use the correct path for your Netbox installation):
-
-```source /opt/netbox/venv/bin/activate```
-
-You can then run the setup to install your plugin using the following command :
-
-```python3 setup.py install```
-
-This will install the plugin for you inside of Netbox's virtual environment (venv).
-
-You then need to edit your Netbox configuration file (```/opt/netbox/netbox/netbox/configuration.py```) to add the plugin to your Netbox configuration adding ```netbox_plugin_mclag``` to the ```PLUGINS``` list as per this example below:
+Edit your Netbox configuration file (```/opt/netbox/netbox/netbox/configuration.py```) to add the plugin to your Netbox configuration, by adding ```netbox_plugin_mclag``` to the ```PLUGINS``` list as per this example below:
 
 ```python
 PLUGINS = [
@@ -146,12 +130,12 @@ See https://netbox.readthedocs.io/en/feature/configuration/data-validation/#fiel
 ```python
 FIELD_CHOICES = {
     'netbox_plugin_mclag.McLag.type+': (
-        ('value', 'Display', 'color'),
+        ('value', 'Display value', 'color'),
     )
 }
 ```
 Remark: 
- - Remove the + after 'netbox_plugin_mclag.McLag.type' to replace the default list, keep the + to add to the list.
+ - Make sure to add the + after 'netbox_plugin_mclag.McLag.type'. This will add your options to the existing ones.
  - Make sure to have a comma after the last entry !
 
 ## Uninstallation
@@ -202,3 +186,7 @@ The following materials were instrumental in developing this plugin:
  * The [Plugins Development](https://docs.netbox.dev/en/stable/plugins/development/) chapter of the NetBox documentation.
  * The Wikipedia page for [Multi-Chassis Link Aggregation Groups](https://en.wikipedia.org/wiki/Multi-chassis_link_aggregation_group)
  * The [Virtual Port Channels](https://www.ciscopress.com/articles/article.asp?p=3150966&seqNum=2) section of the [Port Channels and vPCs chapter](https://www.ciscopress.com/articles/article.asp?p=3150966) from the [Cisco Data Center Fundamentals](https://www.ciscopress.com/store/cisco-data-center-fundamentals-9780137638246) by [Somit Maloo](https://www.ciscopress.com/authors/bio/75b726d0-f107-4c19-98bd-77d9f3558184) and [Iskren Nikolov](https://www.ciscopress.com/authors/bio/301612bc-152f-4827-b31e-ab7a1dd35c61), published by [Cisco Press](https://www.ciscopress.com/).
+
+
+----
+Based on the original code of pv2b https://github.com/pv2b/netbox-plugin-mclag

--- a/netbox_plugin_mclag/__init__.py
+++ b/netbox_plugin_mclag/__init__.py
@@ -7,7 +7,7 @@ class NetBoxMcLagConfig(PluginConfig):
     description = "Manage Multi-Chassis Link Aggregation Groups in Netbox (MC-LAG / MLAG / vPC / etc)"
     author = "Pieter Lambrecht"
     author_email = "pieter.lambrecht@gmail.com"
-    version = "0.3.0"
+    version = "0.3.1"
     base_url = "mclag"
 
 # based original code of pv2b: https://github.com/pv2b/netbox-plugin-mclag

--- a/netbox_plugin_mclag/models.py
+++ b/netbox_plugin_mclag/models.py
@@ -52,6 +52,9 @@ class McLag(NetBoxModel):
         return self.interfaces.all()
     def get_physical_interfaces(self):
         return Interface.objects.filter(lag__mc_lags=self)
+    def get_connected_endpoints(self):
+        return sum([interface.connected_endpoints for interface in Interface.objects.filter(lag__mc_lags=self)], [])
+
 
     class Meta:
         verbose_name="Multi-Chassis Link Aggregation Group"

--- a/netbox_plugin_mclag/models.py
+++ b/netbox_plugin_mclag/models.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.urls import reverse
 
 from netbox.models import NetBoxModel
+from dcim.models import Interface
 
 from netbox_plugin_mclag.choices import LagTypeChoices
 
@@ -47,6 +48,11 @@ class McLag(NetBoxModel):
         return reverse('plugins:netbox_plugin_mclag:mclag', args=[self.pk])
     def get_type_color(self):
         return LagTypeChoices.colors.get(self.type)
+    def get_lag_interfaces(self):
+        return self.interfaces.all()
+    def get_physical_interfaces(self):
+        return Interface.objects.filter(lag__mc_lags=self)
+
     class Meta:
         verbose_name="Multi-Chassis Link Aggregation Group"
         verbose_name_plural="Multi-Chassis Link Aggregation Groups"

--- a/netbox_plugin_mclag/templates/netbox_plugin_mclag/mclag.html
+++ b/netbox_plugin_mclag/templates/netbox_plugin_mclag/mclag.html
@@ -3,7 +3,6 @@
 {% load render_table from django_tables2 %}
 
 {% block content %}
-{{ object.get_endpoints}}
 <div class="row mb-3">
     <div class="col col-md-6">
         <div class="card">

--- a/netbox_plugin_mclag/templates/netbox_plugin_mclag/mclag.html
+++ b/netbox_plugin_mclag/templates/netbox_plugin_mclag/mclag.html
@@ -3,6 +3,7 @@
 {% load render_table from django_tables2 %}
 
 {% block content %}
+{{ object.get_endpoints}}
 <div class="row mb-3">
     <div class="col col-md-6">
         <div class="card">

--- a/netbox_plugin_mclag/views.py
+++ b/netbox_plugin_mclag/views.py
@@ -58,10 +58,10 @@ class McDomainBulkDeleteView(BulkDeleteView):
 class McLagView(ObjectView):
     queryset = McLag.objects.all()
     def get_extra_context(self, request, instance):
-        lag_interfaces_table = InterfaceTable(instance.interfaces.all())
+        lag_interfaces_table = InterfaceTable(instance.get_lag_interfaces())
         lag_interfaces_table.configure(request)
 
-        physical_interfaces_table = InterfaceTable(Interface.objects.filter(lag__mc_lags=instance))
+        physical_interfaces_table = InterfaceTable(instance.get_physical_interfaces())
         physical_interfaces_table.configure(request)
         return {
             'lag_interfaces_table': lag_interfaces_table,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='netbox-plugin-mclag',
-    version='0.3.0',
+    version='0.3.1',
     description='Manage Multi-Chassis Link Aggregation Groups in Netbox (MC-LAG / MLAG / vPC / etc)',
     install_requires=[],
     packages=find_packages(),


### PR DESCRIPTION
Added

McLag.get_lag_interfaces() - returns a queryset of all LAG interfaces
McLag.get_physical_interfaces() - returns a queryset of all LAG Member interfaces
McLag.get_connected_endpoints() - returns a list of all connected endpoints (device)