### PR TITLE
fix: use SerializedPKRelatedField for M2M fields in API serializers

### DIFF
--- a/netbox_plugin_mclag/api/serializers.py
+++ b/netbox_plugin_mclag/api/serializers.py
@@ -1,8 +1,9 @@
 from rest_framework import serializers
 
 from netbox.api.serializers import NetBoxModelSerializer, WritableNestedSerializer
+from netbox.api.fields import SerializedPKRelatedField
 from dcim.api.serializers import DeviceSerializer, InterfaceSerializer
-from dcim.models import Interface
+from dcim.models import Device, Interface
 
 from netbox_plugin_mclag.models import McLag, McDomain
 from netbox_plugin_mclag.util import get_interface_label
@@ -15,24 +16,22 @@ class NestedMcDomainSerializer(WritableNestedSerializer):
     url = serializers.HyperlinkedIdentityField(
         view_name='plugins-api:netbox_plugin_mclag-api:mcdomain-detail'
     )
-    devices = DeviceSerializer(nested=True, many=True)
     display = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = McDomain
-        fields = ('id', 'url', 'name', 'display', 'domain_id', 'devices')
+        fields = ('id', 'url', 'name', 'display', 'domain_id')
 
 
 class NestedMcLagSerializer(WritableNestedSerializer):
     url = serializers.HyperlinkedIdentityField(
         view_name='plugins-api:netbox_plugin_mclag-api:mclag-detail'
     )
-    interfaces = InterfaceSerializer(nested=True, many=True)
     display = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = McLag
-        fields = ('id', 'name', 'display', 'url', 'name', 'lag_id', 'type', 'interfaces')
+        fields = ('id', 'url', 'name', 'display', 'lag_id', 'type')
 
 #
 # Regular serializers
@@ -42,8 +41,14 @@ class McDomainSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(
         view_name='plugins-api:netbox_plugin_mclag-api:mcdomain-detail'
     )
-    mc_lags = NestedMcLagSerializer(many=True)
-    devices = DeviceSerializer(nested=True, many=True)
+    mc_lags = NestedMcLagSerializer(many=True, read_only=True)
+    devices = SerializedPKRelatedField(
+        queryset=Device.objects.all(),
+        serializer=DeviceSerializer,
+        nested=True,
+        many=True,
+        required=False,
+    )
     display = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
@@ -59,7 +64,13 @@ class McLagSerializer(NetBoxModelSerializer):
         view_name='plugins-api:netbox_plugin_mclag-api:mclag-detail'
     )
     mc_domain = NestedMcDomainSerializer()
-    interfaces = InterfaceSerializer(nested=True, many=True)
+    interfaces = SerializedPKRelatedField(
+        queryset=Interface.objects.all(),
+        serializer=InterfaceSerializer,
+        nested=True,
+        many=True,
+        required=False,
+    )
     display = serializers.SerializerMethodField(read_only=True)
 
     class Meta:


### PR DESCRIPTION
## Problem

The REST API endpoints for creating `McDomain` and `McLag` objects are completely broken. Any POST/PUT/PATCH request fails because the serializers use nested serializers for M2M fields, which DRF's default `create()`/`update()` methods don't support.

**McDomain:**
- POST without `mc_lags` → `{"mc_lags": ["This field is required."]}`
- POST with `mc_lags: []` → `AssertionError: The .create() method does not support writable nested fields by default.`

**McLag:**
- POST without `interfaces` → `{"interfaces": ["This field is required."]}`
- POST with `interfaces: [id1, id2]` → same AssertionError

## Root Cause

1. `McDomainSerializer.mc_lags` uses `NestedMcLagSerializer(many=True)` — a writable nested serializer for a reverse FK. Not `read_only` and not `required=False`, so DRF requires it on POST but can't write it.
2. `McDomainSerializer.devices` uses `DeviceSerializer(nested=True, many=True)` for M2M — DRF's default `create()` doesn't handle M2M writes.
3. `McLagSerializer.interfaces` — same M2M issue.
4. Minor: `NestedMcLagSerializer.Meta.fields` has `'name'` listed twice.

## Fix

- Replace `DeviceSerializer`/`InterfaceSerializer` on M2M fields with `SerializedPKRelatedField`, which is the standard NetBox pattern for writable M2M relations. On read it returns the full nested representation; on write it accepts a list of primary keys.
- Mark `mc_lags` as `read_only=True` on `McDomainSerializer` since MC-LAGs are created via their own endpoint.
- Remove M2M fields from nested serializers where they're unnecessary.
- Fix duplicate `'name'` in `NestedMcLagSerializer.Meta.fields`.

## Testing

Tested on NetBox 4.5.2. After this fix:
```bash
# Create domain
curl -X POST /api/plugins/mclag/domains/ -d '{"name": "test", "devices": [1, 2]}'
# ✅ Works

# Create mclag
curl -X POST /api/plugins/mclag/mclags/ -d '{"name": "Po1", "mc_domain": 1, "interfaces": [10, 20], "type": "channel"}'
# ✅ Works
```

Fixes #5